### PR TITLE
JENKINS-52390 Throw appropriate error when the code is not in node block

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -180,6 +180,7 @@ This step executes given command on remote node and responds with output.
 ==== Example
 
 ```groovy
+node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
@@ -190,6 +191,7 @@ This step executes given command on remote node and responds with output.
     sshCommand remote: remote, command: "ls -lrt"
     sshCommand remote: remote, command: "for i in {1..5}; do echo -n \"Loop \$i \"; date ; sleep 1; done"
   }
+}
 ```
 
 === sshScript
@@ -224,6 +226,7 @@ This step executes given script(file) on remote node and responds with output.
 ==== Example
 
 ```groovy
+node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
@@ -234,6 +237,7 @@ This step executes given script(file) on remote node and responds with output.
     writeFile file: 'abc.sh', text: 'ls -lrt'
     sshScript remote: remote, script: "abc.sh"
   }
+}
 ```
 
 === sshPut
@@ -272,6 +276,7 @@ Put a file or directory into the remote host.
 ==== Example
 
 ```groovy
+node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
@@ -282,6 +287,7 @@ Put a file or directory into the remote host.
     writeFile file: 'abc.sh', text: 'ls -lrt'
     sshPut remote: remote, from: 'abc.sh', into: '.'
   }
+}
 ```
 
 === sshGet
@@ -320,6 +326,7 @@ Get a file or directory from the remote host.
 ==== Example
 
 ```groovy
+node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
@@ -329,6 +336,7 @@ Get a file or directory from the remote host.
   stage('Remote SSH') {
     sshGet remote: remote, from: 'abc.sh', into: 'abc_get.sh', override: true
   }
+}
 ```
 
 === sshRemove
@@ -363,6 +371,7 @@ Remove a file or directory on the remote host.
 ==== Example
 
 ```groovy
+node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
@@ -372,6 +381,7 @@ Remove a file or directory on the remote host.
   stage('Remote SSH') {
     sshRemove remote: remote, path: "abc.sh"
   }
+}
 ```
 == Examples
 

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHStepDescriptorImpl.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.sshsteps.util;
 
 import com.google.common.collect.ImmutableSet;
 import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.util.Set;
@@ -20,6 +22,6 @@ public abstract class SSHStepDescriptorImpl extends StepDescriptor {
 
   @Override
   public Set<? extends Class<?>> getRequiredContext() {
-    return ImmutableSet.of(Run.class, TaskListener.class, EnvVars.class);
+    return ImmutableSet.of(Launcher.class, FilePath.class, Run.class, TaskListener.class, EnvVars.class);
   }
 }


### PR DESCRIPTION
# Description
- Update examples to have node.
- Throw appropriate error when the code is not in node block. 

See [JENKINS-52390](https://issues.jenkins-ci.org/browse/JENKINS-52390).