### PR TITLE
Fix description of sshPut and sshGet commands

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -264,7 +264,7 @@ Put a file or directory into the remote host.
 |String, *Mandatory*
 |file or directory path from the workspace.
 
-|to
+|into
 |String, *Mandatory*
 |file or directory path on the remote node.
 
@@ -314,7 +314,7 @@ Get a file or directory from the remote host.
 |String, *Mandatory*
 |file or directory path from the remote node.
 
-|to
+|into
 |String, *Mandatory*
 |file or directory path on current worksapce.
 


### PR DESCRIPTION
# Description

One of mandotory fields for sshPut and sshGet commands is field "into". But in table it was "to" so I updated readme.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.