### PR TITLE
JENKINS-55194 Add logLevel to support debugging and also reduce default excessive logging

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,9 @@
 
 == 1.2.1 (Unreleased)
 
+* https://issues.jenkins-ci.org/browse/JENKINS-55194[JENKINS-55194] - Add logLevel to support debugging and also reduce default excessive logging.
+** Make `filterBy` and `filterRegex` optional.
+
 == 1.2.0
 
 * https://issues.jenkins-ci.org/browse/JENKINS-55194[JENKINS-55194] - Add logLevel to support debugging and also reduce default excessive logging.

--- a/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
@@ -52,12 +52,13 @@ class SSHService implements Serializable {
     /**
      * Register Log handler for all hidetake's classes.
      */
-    private void registerLogHandler() {
+    private void registerLogHandler(message) {
         Logger rootLogger = Logger.getLogger("org.hidetake")
         rootLogger.addHandler(new CustomLogHandler(logger, MDC.get("execution.id")))
         if(remote.logLevel) {
             rootLogger.setLevel(Level.parse(remote.logLevel))
         } else {
+            logger.println(message)
             rootLogger.setLevel(Level.SEVERE)
         }
     }
@@ -171,8 +172,7 @@ class SSHService implements Serializable {
      * @return response from ssh run.
      */
     def executeCommand(String command, boolean sudo) {
-        logger.println("Executing command on $remote.name[$remote.host]: $command sudo: $sudo")
-        registerLogHandler()
+        registerLogHandler("Executing command on $remote.name[$remote.host]: $command sudo: $sudo")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {
@@ -191,8 +191,7 @@ class SSHService implements Serializable {
      * @return response from ssh run.
      */
     def executeScriptFromFile(String pathname) {
-        logger.println("Executing script on $remote.name[$remote.host]: $pathname")
-        registerLogHandler()
+        registerLogHandler("Executing script on $remote.name[$remote.host]: $pathname")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {
@@ -211,8 +210,7 @@ class SSHService implements Serializable {
      * @return response from ssh run.
      */
     def put(String from, String into, String filterBy, String filterRegex) {
-        logger.println("Sending a file/directory to $remote.name[$remote.host]: from: $from into: $into")
-        registerLogHandler()
+        registerLogHandler("Sending a file/directory to $remote.name[$remote.host]: from: $from into: $into")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {
@@ -234,8 +232,7 @@ class SSHService implements Serializable {
      * @return response from ssh run.
      */
     def get(String from, String into, String filterBy, String filterRegex) {
-        logger.println("Receiving a file/directory from $remote.name[$remote.host]: from: $from into: $into")
-        registerLogHandler()
+        registerLogHandler("Receiving a file/directory from $remote.name[$remote.host]: from: $from into: $into")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {
@@ -254,8 +251,7 @@ class SSHService implements Serializable {
      * @return output from ssh's remove operation.
      */
     def remove(String path) {
-        logger.println("Removing a file/directory on $remote.name[$remote.host]: $path")
-        registerLogHandler()
+        registerLogHandler("Removing a file/directory on $remote.name[$remote.host]: $path")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
@@ -31,10 +31,14 @@ public class GetStep extends BasicSSHStep {
   private final String into;
 
   @Getter
-  private final String filterRegex;
+  @Setter
+  @DataBoundSetter
+  private String filterBy = "name";
 
   @Getter
-  private String filterBy;
+  @Setter
+  @DataBoundSetter
+  private String filterRegex;
 
   @Getter
   @Setter
@@ -42,14 +46,9 @@ public class GetStep extends BasicSSHStep {
   private boolean override = false;
 
   @DataBoundConstructor
-  public GetStep(String from, String into, String filterBy, String filterRegex) {
+  public GetStep(String from, String into) {
     this.from = from;
     this.into = into;
-    this.filterRegex = filterRegex;
-    this.filterBy = filterBy;
-    if (Util.fixEmpty(filterRegex) != null && Util.fixEmpty(filterBy) == null) {
-      this.filterBy = "name";
-    }
   }
 
   @Override

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
@@ -6,12 +6,14 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import lombok.Getter;
+import lombok.Setter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
 import org.jenkinsci.plugins.sshsteps.util.SSHStepDescriptorImpl;
 import org.jenkinsci.plugins.sshsteps.util.SSHStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Step to place a file/directory onto a remote node.
@@ -29,20 +31,19 @@ public class PutStep extends BasicSSHStep {
   private final String into;
 
   @Getter
-  private final String filterRegex;
+  @Setter
+  @DataBoundSetter
+  private String filterBy = "name";
 
   @Getter
-  private String filterBy;
+  @Setter
+  @DataBoundSetter
+  private String filterRegex;
 
   @DataBoundConstructor
-  public PutStep(String from, String into, String filterBy, String filterRegex) {
+  public PutStep(String from, String into) {
     this.from = from;
     this.into = into;
-    this.filterRegex = filterRegex;
-    this.filterBy = filterBy;
-    if (Util.fixEmpty(filterRegex) != null && Util.fixEmpty(filterBy) == null) {
-      this.filterBy = "name";
-    }
   }
 
   @Override

--- a/src/test/java/org/jenkinsci/plugins/sshsteps/steps/GetStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sshsteps/steps/GetStepTest.java
@@ -36,8 +36,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class GetStepTest {
 
   final String path = "test.sh";
-  final String filterBy = "";
-  final String filterRegex = "";
+  final String filterBy = "name";
+  final String filterRegex = null;
 
   @Mock
   TaskListener taskListenerMock;
@@ -84,7 +84,7 @@ public class GetStepTest {
 
   @Test
   public void testWithEmptyFromThrowsIllegalArgumentException() throws Exception {
-    final GetStep step = new GetStep("", path, filterBy, filterRegex);
+    final GetStep step = new GetStep("", path);
     stepExecution = new GetStep.Execution(step, contextMock);
 
     // Execute and assert Test.
@@ -97,7 +97,7 @@ public class GetStepTest {
 
   @Test
   public void testWithEmptyIntoThrowsIllegalArgumentException() throws Exception {
-    final GetStep step = new GetStep(path, "", filterBy, filterRegex);
+    final GetStep step = new GetStep(path, "");
     step.setOverride(true);
     stepExecution = new GetStep.Execution(step, contextMock);
 
@@ -111,7 +111,7 @@ public class GetStepTest {
 
   @Test
   public void testSuccessfulExecuteScript() throws Exception {
-    final GetStep step = new GetStep(path, path, filterBy, filterRegex);
+    final GetStep step = new GetStep(path, path);
     step.setOverride(true);
 
     // Since SSHService is a mock, it is not validating remote.

--- a/src/test/java/org/jenkinsci/plugins/sshsteps/steps/PutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sshsteps/steps/PutStepTest.java
@@ -36,8 +36,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class PutStepTest {
 
   final String path = "test.sh";
-  final String filterBy = "";
-  final String filterRegex = "";
+  final String filterBy = "name";
+  final String filterRegex = null;
 
   @Mock
   TaskListener taskListenerMock;
@@ -84,7 +84,7 @@ public class PutStepTest {
 
   @Test
   public void testWithEmptyFromThrowsIllegalArgumentException() throws Exception {
-    final PutStep step = new PutStep("", path, filterBy, filterRegex);
+    final PutStep step = new PutStep("", path);
     stepExecution = new PutStep.Execution(step, contextMock);
 
     // Execute and assert Test.
@@ -97,7 +97,7 @@ public class PutStepTest {
 
   @Test
   public void testWithEmptyIntoThrowsIllegalArgumentException() throws Exception {
-    final PutStep step = new PutStep(path, "", filterBy, filterRegex);
+    final PutStep step = new PutStep(path, "");
     stepExecution = new PutStep.Execution(step, contextMock);
 
     // Execute and assert Test.
@@ -110,7 +110,7 @@ public class PutStepTest {
 
   @Test
   public void testSuccessfulPut() throws Exception {
-    final PutStep step = new PutStep(path, path, filterBy, filterRegex);
+    final PutStep step = new PutStep(path, path);
 
     // Since SSHService is a mock, it is not validating remote.
     stepExecution = new PutStep.Execution(step, contextMock);


### PR DESCRIPTION
# Description

See [JENKINS-55194](https://issues.jenkins-ci.org/browse/JENKINS-55194).

* Making `filterBy` and `filterRegex` optional. 
* Disable custom logging statements when we set log level, such that we can set OFF to see no logs.