### PR TITLE
Addition of explicit pty parameter to sshCommand

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,7 @@
 
 == 1.2.2 (Unreleased)
 
+* Addition of optional parameter pty to sshCommand.
 
 == 1.2.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,7 +2,7 @@
 
 == 1.2.2 (Unreleased)
 
-* Addition of optional parameter pty to sshCommand.
+* https://issues.jenkins-ci.org/browse/JENKINS-56989[JENKINS-56989] -Addition of optional parameter pty to sshCommand.
 
 == 1.2.1
 

--- a/README.adoc
+++ b/README.adoc
@@ -196,6 +196,10 @@ This step executes given command on remote node and responds with output.
 |dryRun
 |boolean, default: `false`
 |If this is true, no actual connection or operation is performed.
+
+|pty
+|boolean, default: `true`
+|If this is true, PTY is allocated to run the command. Setting it to `false` can enable running commands on servers running win32-openssh 
 |===
 
 ==== Example

--- a/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
@@ -169,17 +169,18 @@ class SSHService implements Serializable {
      *
      * @param command shell command.
      * @param sudo execute it as sudo when true.
+     * @param pty allocate PTY
      * @return response from ssh run.
      */
-    def executeCommand(String command, boolean sudo) {
+    def executeCommand(String command, boolean sudo, boolean pty) {
         registerLogHandler("Executing command on $remote.name[$remote.host]: $command sudo: $sudo")
         defineRemote(remote)
         ssh.run {
             session(ssh.remotes."$remote.name") {
                 if (sudo)
-                    executeSudo command, pty: true
+                    executeSudo command, pty: pty
                 else
-                    execute command, pty: true
+                    execute command, pty: pty
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/CommandStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/CommandStep.java
@@ -28,6 +28,10 @@ public class CommandStep extends BasicSSHStep {
   @Getter
   @DataBoundSetter
   private boolean sudo = false;
+  
+  @Getter
+  @DataBoundSetter
+  private boolean pty = true;
 
   @DataBoundConstructor
   public CommandStep(String command) {
@@ -80,7 +84,7 @@ public class CommandStep extends BasicSSHStep {
       @Override
       public Object execute() {
         CommandStep step = (CommandStep) getStep();
-        return getService().executeCommand(step.getCommand(), step.isSudo());
+        return getService().executeCommand(step.getCommand(), step.isSudo(), step.isPty());
       }
     }
   }

--- a/src/test/java/org/jenkinsci/plugins/sshsteps/steps/CommandStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sshsteps/steps/CommandStepTest.java
@@ -93,6 +93,6 @@ public class CommandStepTest {
     stepExecution.run();
 
     // Assert Test
-    verify(sshServiceMock, times(1)).executeCommand("ls -lrt", false);
+    verify(sshServiceMock, times(1)).executeCommand("ls -lrt", false, true);
   }
 }


### PR DESCRIPTION
See [JENKINS-56989](https://issues.jenkins-ci.org/browse/JENKINS-56989).

I added explicit control over PTY allocation because with default allocation sshCommand is unable to properly run commands on servers running win32-openssh. Explicit disabling PTY allocation fix it and commands run without issues.

By default PTY allocation is enabled.

No tests were added because I no testing of PTY is posible with mockups.
