### PR TITLE
JENKINS-56989 Default pty to false for sshCommand

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,7 @@
 
 == 1.2.2 (Unreleased)
 
+* https://issues.jenkins-ci.org/browse/JENKINS-56989[JENKINS-56989] - Default `pty` to `false` for sshCommand.
 
 == 1.2.1
 

--- a/README.adoc
+++ b/README.adoc
@@ -122,6 +122,10 @@ Possible values, refer to java logging https://docs.oracle.com/javase/7/docs/api
 * FINE
 * FINER
 * FINEST (lowest value)
+
+|pty
+|boolean
+|If this is true, a PTY (pseudo-terminal) is allocated on the command execution. Defaults to `false`.
 |===
 
 === Proxy

--- a/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/sshsteps/SSHService.groovy
@@ -177,9 +177,9 @@ class SSHService implements Serializable {
         ssh.run {
             session(ssh.remotes."$remote.name") {
                 if (sudo)
-                    executeSudo command, pty: true
+                    executeSudo command
                 else
-                    execute command, pty: true
+                    execute command
             }
         }
     }


### PR DESCRIPTION
# Description

See [JENKINS-56989](https://issues.jenkins-ci.org/browse/JENKINS-56989).

* Default `pty` to `false` for sshCommand
* This setting should be default to false by default not sure why I had it `true` during the initial phase. 
* Tested this locally and is working for the nodes (LINUX) that we are running on. 
* And this PTY is also applicable for other steps, so instead it is good to have control at the remote level. 
