### PR TITLE
Configure release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+_extends: .github
+tag-template: ssh-steps-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH


### PR DESCRIPTION
In addition to this the respective GitHub Application needs to be enabled, see https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc