### PR TITLE
Adjusted DisplayName to have valid gdsl

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
@@ -66,7 +66,7 @@ public class GetStep extends BasicSSHStep {
 
     @Override
     public String getDisplayName() {
-      return getPrefix() + getFunctionName() + " - Get a file/directory from remote node.";
+      return getPrefix() + getFunctionName() + " - Get a file or directory from remote node.";
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
@@ -61,7 +61,7 @@ public class PutStep extends BasicSSHStep {
 
     @Override
     public String getDisplayName() {
-      return getPrefix() + getFunctionName() + " - Put a file/directory on remote node.";
+      return getPrefix() + getFunctionName() + " - Put a file or directory on remote node.";
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/RemoveStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/RemoveStep.java
@@ -44,7 +44,7 @@ public class RemoveStep extends BasicSSHStep {
 
     @Override
     public String getDisplayName() {
-      return getPrefix() + getFunctionName() + " - Remove a file/directory from remote node.";
+      return getPrefix() + getFunctionName() + " - Remove a file or directory from remote node.";
     }
   }
 


### PR DESCRIPTION
# Description

Adjusted DisplayName to have valid `gdsl`. If you axport the gdsl with it, you will see errors in the generated gdsl file. So I think the easiest fix is to replace the slash with an or.

![image](https://user-images.githubusercontent.com/22742658/221183790-e270e138-174f-4f05-9a0d-d1d15f76b8b9.png)


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.
