### PR TITLE
Docs/file transfer protocols

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,7 @@ Most of the steps in this plugin require a common step variable called `remote`,
 
 |fileTransfer
 |String
-|File transfer method, that is `SFTP` or `SCP`. Defaults to `SFTP`.
+|File transfer method, that is `sftp` or `scp`. Defaults to `sftp`.
 
 |encoding
 |String

--- a/README.adoc
+++ b/README.adoc
@@ -373,11 +373,16 @@ node {
   def remote = [:]
   remote.name = 'test'
   remote.host = 'test.domain.com'
+  remote.fileTransfer = 'scp'
   remote.user = 'root'
   remote.password = 'password'
   remote.allowAnyHosts = true
   stage('Remote SSH') {
     sshGet remote: remote, from: 'abc.sh', into: 'abc_get.sh', override: true
+  }
+  stage('Retrieve files with regex') {
+    def regexPattern = ".+\\.(log|csv)\$"
+    sshGet remote: remote, from: '/home/jenkins/', filterRegex: regexPattern, into: 'tests/', override: true
   }
 }
 ```


### PR DESCRIPTION
# Description
The documentation on different ssh transfer protocols indicated that `SFTP` and `SCP` were valid settings to the `fileTransfer` option of the `Remote` map. However, according to the [Groovy documentation](https://javadoc.io/doc/org.hidetake/groovy-ssh/latest/org/hidetake/groovy/ssh/session/transfer/FileTransferMethod.html), the valid options are lower case, i.e., `sftp` and `scp`.

In addition, I thought another example on how one could use the `filterRegex` parameter to `sshGet` could be useful, as well as how to properly select the file transfer protocol. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.
