### PR TITLE
Update `groovy-ssh` to `2.11.2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,11 @@
       <version>${assertj-core.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- <dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>
-    </dependency> -->
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.361.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <groovy.ssh.version>2.10.1</groovy.ssh.version>
+    <groovy.ssh.version>2.11.2</groovy.ssh.version>
     <lombok.version>1.18.24</lombok.version>
     <assertj-core.version>3.24.2</assertj-core.version>
   </properties>
@@ -117,6 +117,16 @@
       <artifactId>assertj-core</artifactId>
       <version>${assertj-core.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.6/version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,11 @@
       <version>${assertj-core.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.6/version>
+      <version>2.0.6</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,6 @@
           <artifactId>groovy-all</artifactId>
           <groupId>org.codehaus.groovy</groupId>
         </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
       <artifactId>slf4j-api</artifactId>
       <version>2.0.6</version>
     </dependency>
+<dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-log4j12</artifactId>
+    <version>2.0.7</version>
+    <scope>runtime</scope>
+</dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.hidetake</groupId>
       <artifactId>groovy-ssh</artifactId>
       <version>${groovy.ssh.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
           <artifactId>groovy-all</artifactId>
           <groupId>org.codehaus.groovy</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -117,17 +121,6 @@
       <artifactId>assertj-core</artifactId>
       <version>${assertj-core.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>2.0.6</version>
-    </dependency>
-    <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>2.0.6</version>
-        <scope>runtime</scope>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,12 @@
       <artifactId>slf4j-api</artifactId>
       <version>2.0.6</version>
     </dependency>
-<dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-log4j12</artifactId>
-    <version>2.0.6</version>
-    <scope>runtime</scope>
-</dependency>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>2.0.6</version>
+        <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -121,17 +121,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
       <version>2.0.6</version>
     </dependency>
 <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-log4j12</artifactId>
-    <version>2.0.7</version>
+    <version>2.0.6</version>
     <scope>runtime</scope>
 </dependency>
   </dependencies>


### PR DESCRIPTION
The impetus for this PR is that currently, it is not possible to use any SSH algorithm with the `ssh-step` plugin except for `ssh-rsa` `SHA1`. This is problematic because distros are starting to disallow this by default (`ubuntu` `jammy` for example). In order to use OpenSSH format keys or even `rsa` keys of a different type we have to get over this hurdle.

I'm going to trust that the tests that currently exist will bear out the expected functionality.

https://issues.jenkins.io/browse/JENKINS-65533

# Description

See [JENKINS-65533](https://issues.jenkins-ci.org/browse/JENKINS-65533).

The impetus for this PR is that currently, it is not possible to use any SSH algorithm with the `ssh-step` plugin except for `ssh-rsa` `SHA1`. This is problematic because distros are starting to disallow this by default (`ubuntu` `jammy` for example). In order to use OpenSSH format keys or even `rsa` keys of a different type we have to get over this hurdle.

I'm going to trust that the tests that currently exist will bear out the expected functionality.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x ] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.
