### PR TITLE
use jsch plugin instead of version bundled in groovy-ssh library to support newer algorithms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsch</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
@@ -85,6 +89,10 @@
       <artifactId>groovy-ssh</artifactId>
       <version>${groovy.ssh.version}</version>
       <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>com.jcraft</groupId>
+        </exclusion>
         <exclusion>
           <artifactId>groovy-all</artifactId>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Use of plugin https://plugins.jenkins.io/jsch/ to remove transitive dependency from groovy-ssh.
Alternative to bumping groovy-ssh version.

Related issues
https://issues.jenkins.io/browse/JENKINS-65533