### PR TITLE
Test with Java 21

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,6 +4,6 @@
   <extension>
     <artifactId>git-changelist-maven-extension</artifactId>
     <groupId>io.jenkins.tools.incrementals</groupId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11]
+    [platform: 'linux', jdk: 21]
+    [platform: 'windows', jdk: 17]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 21]
-    [platform: 'windows', jdk: 17]
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.54</version>
+    <version>4.74</version>
   </parent>
   <artifactId>ssh-steps</artifactId>
   <version>${revision}.${changelist}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <groovy.ssh.version>2.10.1</groovy.ssh.version>
-    <lombok.version>1.18.24</lombok.version>
+    <lombok.version>1.18.30</lombok.version>
     <assertj-core.version>3.24.2</assertj-core.version>
   </properties>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   <properties>
     <revision>2.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <java.level>8</java.level>
-    <jenkins.version>2.361.1</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <groovy.ssh.version>2.10.1</groovy.ssh.version>
     <lombok.version>1.18.24</lombok.version>
@@ -60,11 +59,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>1763.v092b_8980a_f5e</version>
+        <version>2102.v854b_fec19c92</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -91,25 +90,16 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>5.13.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
# Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Includes or supersedes pull requests:

* #101
* #97
* #89	
* #86

[JENKINS-65533](https://issues.jenkins.io/browse/JENKINS-65533) requests support for current OpenSSH keys.  #101 provides that support by switching to the jsch plugin that is now using the mwiede fork of jsch instead of using the original unmaintained jsch.

# Test instructions

Run automated tests with Java 21 and Java 17.

Use the plugin with an OpenSSH key generated with `ssh-keygen -t ed25519`

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description.
- [x] Reviewed the code.
- [x] Verified that the appropriate tests have been written or valid explanation given.
- [x] If applicable, test installing this plugin on the Jenkins instance.
