### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHStepExecution.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.sshsteps.util;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Launcher;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -13,7 +14,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.apache.log4j.MDC;
@@ -39,7 +39,7 @@ public abstract class SSHStepExecution<T> extends StepExecution {
   private transient String threadName;
   private transient Throwable stopCause;
 
-  protected SSHStepExecution(BasicSSHStep step, @Nonnull StepContext context)
+  protected SSHStepExecution(BasicSSHStep step, @NonNull StepContext context)
       throws IOException, InterruptedException {
     super(context);
     listener = context.get(TaskListener.class);
@@ -116,7 +116,7 @@ public abstract class SSHStepExecution<T> extends StepExecution {
   }
 
   @Override
-  public @Nonnull
+  public @NonNull
   String getStatus() {
     if (threadName != null) {
       return "running in thread: " + threadName;


### PR DESCRIPTION
# Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Confirmed that automated tests pass on Linux with Java 21.  No automated tests needed because this is a behavior preserving transformation.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.
