### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.75</version>
+    <version>5.7</version>
   </parent>
   <artifactId>ssh-steps</artifactId>
   <version>${revision}.${changelist}</version>
@@ -17,8 +17,8 @@
     <revision>2.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.361</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <groovy.ssh.version>2.10.1</groovy.ssh.version>
     <lombok.version>1.18.30</lombok.version>
@@ -65,7 +65,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>2102.v854b_fec19c92</version>
+        <version>4136.vca_c3202a_7fd1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -121,10 +121,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/CommandStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/CommandStep.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.plugins.sshsteps.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
 import org.jenkinsci.plugins.sshsteps.util.SSHStepDescriptorImpl;
@@ -18,14 +21,14 @@ import org.kohsuke.stapler.DataBoundSetter;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class CommandStep extends BasicSSHStep {
 
+  @Serial
   private static final long serialVersionUID = 7492916747486604582L;
 
-  @Getter
   private final String command;
 
-  @Getter
   @DataBoundSetter
   private boolean sudo = false;
 
@@ -47,6 +50,7 @@ public class CommandStep extends BasicSSHStep {
       return "sshCommand";
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return getPrefix() + getFunctionName() + " - Execute command on remote node.";
@@ -55,6 +59,7 @@ public class CommandStep extends BasicSSHStep {
 
   public static class Execution extends SSHStepExecution {
 
+    @Serial
     private static final long serialVersionUID = -5293952534324828128L;
 
     protected Execution(CommandStep step, StepContext context)

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/GetStep.java
@@ -1,10 +1,13 @@
 package org.jenkinsci.plugins.sshsteps.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
@@ -20,27 +23,24 @@ import org.kohsuke.stapler.DataBoundSetter;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetStep extends BasicSSHStep {
 
+  @Serial
   private static final long serialVersionUID = -8831609599645560972L;
 
-  @Getter
   private final String from;
 
-  @Getter
   private final String into;
 
-  @Getter
   @Setter
   @DataBoundSetter
   private String filterBy = "name";
 
-  @Getter
   @Setter
   @DataBoundSetter
   private String filterRegex;
 
-  @Getter
   @Setter
   @DataBoundSetter
   private boolean override = false;
@@ -64,6 +64,7 @@ public class GetStep extends BasicSSHStep {
       return "sshGet";
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return getPrefix() + getFunctionName() + " - Get a file or directory from remote node.";
@@ -72,6 +73,7 @@ public class GetStep extends BasicSSHStep {
 
   public static class Execution extends SSHStepExecution {
 
+    @Serial
     private static final long serialVersionUID = 8544114488028417422L;
 
     protected Execution(GetStep step, StepContext context)

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/PutStep.java
@@ -1,10 +1,13 @@
 package org.jenkinsci.plugins.sshsteps.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
@@ -20,22 +23,20 @@ import org.kohsuke.stapler.DataBoundSetter;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class PutStep extends BasicSSHStep {
 
+  @Serial
   private static final long serialVersionUID = 9183111587222550149L;
 
-  @Getter
   private final String from;
 
-  @Getter
   private final String into;
 
-  @Getter
   @Setter
   @DataBoundSetter
   private String filterBy = "name";
 
-  @Getter
   @Setter
   @DataBoundSetter
   private String filterRegex;
@@ -59,6 +60,7 @@ public class PutStep extends BasicSSHStep {
       return "sshPut";
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return getPrefix() + getFunctionName() + " - Put a file or directory on remote node.";
@@ -67,6 +69,7 @@ public class PutStep extends BasicSSHStep {
 
   public static class Execution extends SSHStepExecution {
 
+    @Serial
     private static final long serialVersionUID = -4497192469254138827L;
 
     protected Execution(PutStep step, StepContext context)

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/RemoveStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/RemoveStep.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.plugins.sshsteps.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
 import org.jenkinsci.plugins.sshsteps.util.SSHStepDescriptorImpl;
@@ -17,11 +20,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class RemoveStep extends BasicSSHStep {
 
+  @Serial
   private static final long serialVersionUID = -177489327125117255L;
 
-  @Getter
   private final String path;
 
   @DataBoundConstructor
@@ -42,6 +46,7 @@ public class RemoveStep extends BasicSSHStep {
       return "sshRemove";
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return getPrefix() + getFunctionName() + " - Remove a file or directory from remote node.";
@@ -50,6 +55,7 @@ public class RemoveStep extends BasicSSHStep {
 
   public static class Execution extends SSHStepExecution {
 
+    @Serial
     private static final long serialVersionUID = 862708152481251266L;
 
     protected Execution(RemoveStep step, StepContext context)

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/steps/ScriptStep.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/steps/ScriptStep.java
@@ -1,10 +1,13 @@
 package org.jenkinsci.plugins.sshsteps.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.sshsteps.util.SSHMasterToSlaveCallable;
 import org.jenkinsci.plugins.sshsteps.util.SSHStepDescriptorImpl;
@@ -18,11 +21,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class ScriptStep extends BasicSSHStep {
 
+  @Serial
   private static final long serialVersionUID = 7358533459289529723L;
 
-  @Getter
   private final String script;
 
   @DataBoundConstructor
@@ -43,6 +47,7 @@ public class ScriptStep extends BasicSSHStep {
       return "sshScript";
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return getPrefix() + getFunctionName() + " - Execute script(file) on remote node.";
@@ -51,6 +56,7 @@ public class ScriptStep extends BasicSSHStep {
 
   public static class Execution extends SSHStepExecution {
 
+    @Serial
     private static final long serialVersionUID = 6008070200393301960L;
 
     protected Execution(ScriptStep step, StepContext context)

--- a/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHMasterToSlaveCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/sshsteps/util/SSHMasterToSlaveCallable.java
@@ -5,6 +5,7 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.UUID;
 import jenkins.security.MasterToSlaveCallable;
+import lombok.Getter;
 import org.apache.log4j.MDC;
 import org.jenkinsci.plugins.sshsteps.SSHService;
 import org.jenkinsci.plugins.sshsteps.steps.BasicSSHStep;
@@ -16,8 +17,10 @@ import org.jenkinsci.plugins.sshsteps.steps.BasicSSHStep;
  */
 public abstract class SSHMasterToSlaveCallable extends MasterToSlaveCallable<Object, IOException> {
 
+  @Getter
   private final BasicSSHStep step;
   private final TaskListener listener;
+  @Getter
   private SSHService service;
 
   public SSHMasterToSlaveCallable(BasicSSHStep step, TaskListener listener) {
@@ -40,11 +43,4 @@ public abstract class SSHMasterToSlaveCallable extends MasterToSlaveCallable<Obj
 
   protected abstract Object execute();
 
-  public BasicSSHStep getStep() {
-    return step;
-  }
-
-  public SSHService getService() {
-    return service;
-  }
 }


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
