### PR TITLE
Bump plugin pom to 6.2111.v8b_6a_1d599df3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2108.v08c2b_01b_cf4d</version>
+    <version>6.2111.v8b_6a_1d599df3</version>
   </parent>
   <artifactId>ssh-steps</artifactId>
   <version>${revision}.${changelist}</version>


### PR DESCRIPTION
# Description

Without this, the BOM release was blocked yesterday (see https://github.com/jenkinsci/bom/issues/6190) because the PCT are run with Java 17 when not on the weekly branch. 

Until this is merged and released, we cannot bump ssh-steps plugin version in the BOM.

To validate the change: run `mvn compile` with Java 17. Before the fix:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.2:enforce (display-info) on project ssh-steps:
[ERROR] Rule 2: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK /home/alecharp/.local/share/mise/installs/java/temurin-17.0.17+10 is version 17.0.17 which is not in the allowed range [21,).
```

After the fix, everything is good.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, test installing this plugin on the Jenkins instance.
