### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: .github

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 
 image::docs/static/images/JenkinsPlusSSH.png[Jenkins,300]
 
-link:https://ci.jenkins.io/job/Plugins/job/ssh-steps-plugin/job/master/[image:https://ci.jenkins.io/job/Plugins/job/ssh-steps-plugin/job/master/badge/icon[Build]] image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License] link:https://plugins.jenkins.io/ssh-steps[image:https://img.shields.io/badge/SSH%20Steps-WIKI-blue.svg[Wiki]] image:https://badges.gitter.im/jenkinsci/ssh-steps-plugin.svg[link="https://gitter.im/jenkinsci/ssh-steps-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+link:https://ci.jenkins.io/job/Plugins/job/ssh-steps-plugin/job/master/[image:https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fssh-steps-plugin%2Fmaster[Build]] image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License] link:https://plugins.jenkins.io/ssh-steps[image:https://img.shields.io/badge/SSH%20Steps-WIKI-blue.svg[Wiki]] image:https://badges.gitter.im/jenkinsci/ssh-steps-plugin.svg[link="https://gitter.im/jenkinsci/ssh-steps-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 
 Jenkins pipeline steps which provides SSH facilities such as command execution or file transfer for continuous delivery. It internally uses the library of https://github.com/int128/groovy-ssh[Groovy SSH].
 


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
