### PR TITLE
Keep Groovy bytecode compatible with Jenkins runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,9 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <version>5.1.0</version>
+        <configuration>
+          <targetBytecode>1.8</targetBytecode>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary

- configure GMavenPlus to emit Java 8 bytecode for the plugin Groovy sources
- keep Java sources at the repository Java 17 release target
- retain GMavenPlus compatibility validation and Jenkins-provided Groovy 2.4.21

Dependabot PR #196 upgrades GMavenPlus to 5.1.0. The plugin correctly rejects the inherited Java 17 target because [Groovy 2.4 cannot emit Java 17 bytecode](https://groovy.github.io/GMavenPlus/compile-mojo.html#targetBytecode). Java 8 is the supported target for that runtime and matches the bytecode Groovy 2.4 can produce; this does not lower the project Java baseline.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -V -B --no-transfer-progress clean verify`
  - 30 tests run, 0 failures, 0 errors, 1 skipped
  - HPI assembly succeeds
  - Maven dependency gates pass
  - SpotBugs reports no findings
- `javap -verbose` confirms:
  - Groovy `SSHService`: class-file major version 52 (Java 8)
  - Java `CommandStep`: class-file major version 61 (Java 17)
- `git diff --check`

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`